### PR TITLE
Fix comments partial name bug

### DIFF
--- a/wowchemy/layouts/partials/comments.html
+++ b/wowchemy/layouts/partials/comments.html
@@ -1,7 +1,7 @@
 {{ $provider := trim (site.Params.comments.provider | lower) " " }}
 
 {{ if $provider }}
-  {{ $provider_tpl := printf "partials/comments/%s" $provider }}
+  {{ $provider_tpl := printf "partials/comments/%s.html" $provider }}
   {{ $provider_exists := templates.Exists $provider_tpl }}
   {{ if not $provider_exists }}
     {{ errorf "The '%s' comment provider was not found." $provider }}


### PR DESCRIPTION
### Purpose

Fix comments partial name that causes an error: `The 'disqus' comment provider was not found.`